### PR TITLE
Fix typos

### DIFF
--- a/src/component/polyline.rs
+++ b/src/component/polyline.rs
@@ -12,7 +12,7 @@ use tui::{
 
 use crate::{
     app::App,
-    ui::color::{gradiant, Rgb},
+    ui::color::{gradient, Rgb},
 };
 
 pub fn draw<B: Backend>(
@@ -78,7 +78,7 @@ pub fn draw<B: Backend>(
                         y1: from.1 + 1.0,
                         x2: to.0 + 1.0,
                         y2: to.1 + 1.0,
-                        color: gradiant(
+                        color: gradient(
                             Rgb {
                                 red: 0,
                                 green: 255,

--- a/src/component/splits.rs
+++ b/src/component/splits.rs
@@ -10,7 +10,7 @@ use tui::{
     Frame,
 };
 
-use crate::{app::App, ui::color::{gradiant, Rgb}, store::activity::ActivitySplit};
+use crate::{app::App, ui::color::{gradient, Rgb}, store::activity::ActivitySplit};
 
 pub fn draw<B: Backend>(
     app: &mut App,
@@ -67,7 +67,7 @@ pub fn draw<B: Backend>(
                 .use_unicode(true)
                 .style(Style::default().fg(Color::White))
                 .gauge_style(Style::default().fg(
-                        gradiant(
+                        gradient(
                             Rgb { red: 0, green: 255, blue: 0 },
                             Rgb { red: 255, green: 0, blue: 0 },
                             split.seconds_per_meter() - min,

--- a/src/sync/convert.rs
+++ b/src/sync/convert.rs
@@ -10,19 +10,19 @@ use crate::event::logger::Logger;
 use crate::store::activity::Activity;
 
 
-pub struct AcitivityConverter<'a> {
+pub struct ActivityConverter<'a> {
     pool: &'a SqlitePool,
     event_sender: EventSender,
     logger: Logger,
 }
 
-impl AcitivityConverter<'_> {
+impl ActivityConverter<'_> {
     pub fn new(
         pool: &SqlitePool,
         event_sender: EventSender,
         logger: Logger,
-    ) -> AcitivityConverter<'_> {
-        AcitivityConverter {
+    ) -> ActivityConverter<'_> {
+        ActivityConverter {
             pool,
             event_sender,
             logger,

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -6,7 +6,7 @@ use tokio::{task, sync::mpsc::Receiver};
 
 use crate::{authenticator::Authenticator, event::{input::EventSender, logger::Logger}, client::{StravaConfig, new_strava_client}};
 
-use self::{ingest_activities::IngestActivitiesTask, ingest_activity::IngestActivityTask, convert::AcitivityConverter};
+use self::{ingest_activities::IngestActivitiesTask, ingest_activity::IngestActivityTask, convert::ActivityConverter};
 
 pub mod convert;
 pub mod ingest_activities;
@@ -47,7 +47,7 @@ pub async fn spawn_sync<'a>(
                     .execute()
                     .await
                     .unwrap();
-                AcitivityConverter::new(&pool, event_sender.clone(), logger.clone())
+                ActivityConverter::new(&pool, event_sender.clone(), logger.clone())
                     .convert()
                     .await
                     .unwrap();

--- a/src/ui/color.rs
+++ b/src/ui/color.rs
@@ -27,7 +27,7 @@ impl Rgb {
     }
 }
 
-pub fn gradiant(start: Rgb, end: Rgb, offset: f64, size: f64) -> Rgb {
+pub fn gradient(start: Rgb, end: Rgb, offset: f64, size: f64) -> Rgb {
     let rdiff = (end.red as f64 - start.red as f64) / size;
     let gdiff = (end.green as f64 - start.green as f64) / size;
     let bdiff = (end.blue as f64 - start.blue as f64) / size;
@@ -41,11 +41,11 @@ pub fn gradiant(start: Rgb, end: Rgb, offset: f64, size: f64) -> Rgb {
 
 #[cfg(test)]
 mod tests {
-    use super::{gradiant, Rgb};
+    use super::{gradient, Rgb};
 
     #[test]
-    fn test_gradiant() {
-        let rgb = gradiant(
+    fn test_gradient() {
+        let rgb = gradient(
             Rgb {
                 red: 0,
                 green: 255,


### PR DESCRIPTION
Help for a fresh project!

Tool used to correct misspellings: `typos`.

🎈 Some fun: `ratatui` -> `ratatouille`

![image](https://github.com/dantleech/strava-rs/assets/952007/349cbb20-46e9-4a2f-b242-91cbbc9b0759)
