### PR TITLE
Cache cargo packages in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,5 +16,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Lint and test
       run: make


### PR DESCRIPTION
It will be a bit 🐎 faster.

![image](https://github.com/dantleech/strava-rs/assets/952007/398bb2aa-00b8-4b8b-be5c-bc9dfcfe1ccd)
